### PR TITLE
implemented a more efficient calculation of the delong placements

### DIFF
--- a/src/delong.cpp
+++ b/src/delong.cpp
@@ -2,6 +2,8 @@
    (partial) area under the curve, confidence intervals and comparison. 
    Copyright (C) 2014 Xavier Robin
 
+   * modified by Stefan Siegert <stefan_siegert@gmx.de>, January 2016
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
@@ -27,7 +29,7 @@ double MWkernel(double x, double y) {
 
 
 // [[Rcpp::export]]
-List delongPlacementsCpp(List roc) {  
+List delongPlacementsCpp_old(List roc) {  
   NumericVector cases = roc["cases"];
 	NumericVector controls = roc["controls"];
 	std::size_t xsize = cases.size();
@@ -56,4 +58,93 @@ List delongPlacementsCpp(List roc) {
 	ret["X"] = X;
 	ret["Y"] = Y;
 	return(ret);
+}
+
+bool _cmp(std::pair<int, double> l, std::pair<int, double> r) {
+  return l.second < r.second;
+}
+
+// [[Rcpp::export]]
+List delongPlacementsCpp(List roc) {  
+
+  int i, j, k, m, n, mdupl, ndupl, L;
+
+  std::vector<double> cases = roc["cases"];
+  std::vector<double> controls = roc["controls"];
+  m = cases.size();
+  n = controls.size();
+  L = m + n;
+
+  // concatenate cases and controls into a vector of L pairs of the form
+  // (index, value), also save class labels (1 for cases, 0 for controls)
+  std::vector< std::pair<int, double> > Z;
+  std::vector< bool > labels;
+  for (i = 0; i < m; i++) {
+    Z.push_back(std::pair<int, double>(i, cases.at(i)));
+    labels.push_back(true);
+  }
+  for (j = 0; j < n; j++) {
+    Z.push_back(std::pair<int, double>(m+j, controls.at(j)));
+    labels.push_back(false);
+  }
+
+  // sort Z from smallest to largest value, so Z holds the order indices and
+  // order statistics of all classifiers
+  std::sort(Z.begin(), Z.end(), _cmp);
+
+  // the following calculates the "Delong-placements" X and Y in a single pass
+  // over the vector Z, instead of having to double loop over all pairs of
+  // (X_i, Y_j)
+  std::vector< double > XY(L, 0.0);  // vector to hold the unnormalised X and Y values
+  std::vector< int > X_inds, Y_inds; // temporary vectors to save indices of duplicates
+  m = n = i = 0;                     // initialisation
+  while (i < L) {
+    X_inds.clear();
+    Y_inds.clear();
+    mdupl = ndupl = 0;
+    while(1) {
+      j = Z.at(i).first;
+      if (labels.at(j)) {
+        mdupl++;
+        X_inds.push_back(j);
+      } else {
+        ndupl++;
+        Y_inds.push_back(j);
+      }
+      if (i == L-1) {
+        break;
+      }
+      if (Z.at(i).second != Z.at(i+1).second) {
+        break;
+      }
+      i++;
+    }
+    for (k = 0; k < mdupl; k++) {
+      XY.at(X_inds.at(k)) = n + ndupl/2.0;
+    }
+    for (k = 0; k < ndupl; k++) {
+      XY.at(Y_inds.at(k)) = m + mdupl/2.0;
+    }
+    n += ndupl;
+    m += mdupl;
+    i++;
+  }
+
+  double sum = 0.0;
+  std::vector<double> X, Y;
+
+  for (i = 0; i < L; i++) {
+    if (labels.at(i)) {
+      sum += XY.at(i);
+      X.push_back(XY.at(i) / n);
+    } else {
+      Y.push_back(1.0 - XY.at(i) / m);
+    }
+  }
+
+  List ret;
+  ret["theta"] = sum / (m*n);
+  ret["X"] = X;
+  ret["Y"] = Y;
+  return(ret);
 }


### PR DESCRIPTION
Hi there,

The current implementation of Delongs method in delong.cpp required to loop over all pairs of cases and controls, so computational complexity is O(N^2). I implemented a different algorithm to calculate the Delong placements based on the order statistics of cases and controls, which runs in O(NlogN). For small sample sizes of around 10 the new algorithm is slightly slower than the old one that loops over all pairs. But for large sample sizes (>100) there is a massive improvement in run time. The algorithm I implemented is similar to the one proposed in "Sun and Xu: Fast Implementation of DeLongs Algorithm for Comparing the Areas Under Correlated Receiver Operating Characteristic Curves. IEEE Signal Processing Letters, 21(11):1389-1393, 2014."

I ran some tests to verify that the output of old and new code is the same. Needless to say that more testing is always good.

Maybe this is helpful for future releases.

Cheers, Stefan