### PR TITLE
keep order of list items

### DIFF
--- a/R/ggroc.R
+++ b/R/ggroc.R
@@ -100,6 +100,7 @@ ggroc.list <- function(data, aes = c("colour", "alpha", "linetype", "size", "gro
 	
 	# Make a big data.frame
 	coord.dfs <- do.call(rbind, coord.dfs)
+    coord.dfs$name <- factor(coord.dfs$name, as.vector(names(data)))
 	
 	# Prepare the aesthetics
 	aes.ggplot <- get.aes.for.ggplot(data[[1]], legacy.axes, aes)


### PR DESCRIPTION
This PR addresses the issue #58 by making `name` a factor with original ordering:

```coord.dfs$name <- factor(coord.dfs$name, as.vector(names(data)))```