### PR TITLE
Mention coords() handles multiple points in its description

### DIFF
--- a/man/coords.Rd
+++ b/man/coords.Rd
@@ -9,7 +9,8 @@
 }
 \description{
   This function returns the coordinates of the ROC curve at the
-  specified point.
+  specified point (or multiple points, e.g. all potential thresholds
+  based on observed data).
 }
 \usage{
 coords(...)


### PR DESCRIPTION
Hi,  
This extends the `coords()` function description so users can tell at a glance this function can cover multiple points, not just one. This also seems useful because argument x, by default, uses `"all"` thresholds in the roc object.