### PR TITLE
Also skip if missing ggplot2

### DIFF
--- a/tests/testthat/helper-vdiffr.R
+++ b/tests/testthat/helper-vdiffr.R
@@ -2,5 +2,6 @@
 # Skip expect_doppelganger if vdiffr is not installed
 expect_doppelganger <- function(title, fig, path = NULL, ...) {
 	testthat::skip_if_not_installed("vdiffr")
+	testthat::skip_if_not_installed("ggplot2")
 	vdiffr::expect_doppelganger(title, fig, path = path, ...)
 }


### PR DESCRIPTION
ggplot2 is only Suggests for vdiffr, so skipping for vdiffr is not sufficient to ensure doppelganger tests run.