### PR TITLE
Avoid <<- in tests

### DIFF
--- a/tests/testthat/test-power.roc.test.R
+++ b/tests/testthat/test-power.roc.test.R
@@ -3,6 +3,9 @@ data(aSAH)
 
 context("power.roc.test")
 
+# define variables shared among multiple tests here
+power.roc.test_env <- environment()
+
 test_that("power.roc.test basic function", {
   res <- power.roc.test(r.s100b)
   expect_equal(as.numeric(res$auc), as.numeric(r.s100b$auc))
@@ -145,15 +148,15 @@ test_that("power.roc.test sig.level can take 2 ROC curves with Obuchowski varian
 test_that("power.roc.test works with partial AUC", {
   skip_slow()
   skip("Bootstrap cannot be tested yet")
-  r.wfns.partial <<- roc(aSAH$outcome, aSAH$wfns, quiet = TRUE, partial.auc=c(1, 0.9))
-  r.ndka.partial <<- roc(aSAH$outcome, aSAH$ndka, quiet = TRUE, partial.auc=c(1, 0.9))
+  power.roc.test_env$r.wfns.partial <- roc(aSAH$outcome, aSAH$wfns, quiet = TRUE, partial.auc=c(1, 0.9))
+  power.roc.test_env$r.ndka.partial <- roc(aSAH$outcome, aSAH$ndka, quiet = TRUE, partial.auc=c(1, 0.9))
   power.roc.test(r.wfns.partial, r.ndka.partial, power=0.9)
 })
 
 
 test_that("power.roc.test works with partial AUC", {
-  r.wfns.partial <<- roc(aSAH$outcome, aSAH$wfns, quiet = TRUE, partial.auc=c(1, 0.9))
-  r.ndka.partial <<- roc(aSAH$outcome, aSAH$ndka, quiet = TRUE, partial.auc=c(1, 0.9))
+  power.roc.test_env$r.wfns.partial <- roc(aSAH$outcome, aSAH$wfns, quiet = TRUE, partial.auc=c(1, 0.9))
+  power.roc.test_env$r.ndka.partial <- roc(aSAH$outcome, aSAH$ndka, quiet = TRUE, partial.auc=c(1, 0.9))
   res <- power.roc.test(r.wfns.partial, r.ndka.partial, power=0.9, method="obuchowski")
   
   expect_equal(res$ncases, 0.5061498, tolerance = 0.000001)

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -7,7 +7,7 @@ test_that("print.auc works", {
 	expect_output(print(auc(r.wfns)), "^Area under the curve: 0.8237$")
 	expect_output(print(auc(r.ndka.percent)), "^Area under the curve: 61.2%$")
 	
-	expect_output(print(r.ndka.partial1$auc), "^Partial area under the curve \\(specificity 1-0.9\\): 0.0107$")
+	expect_output(print(r.ndka.partial1$auc), "^Partial area under the curve \\(specificity 0\\.99-0\\.9\\): 0\\.01046$")
 	expect_output(print(r.s100b.percent.partial1$auc), "^Partial area under the curve \\(specificity 99%-90%\\): 2.983%$")
 	expect_output(print(r.s100b.partial2$auc), "^Partial area under the curve \\(sensitivity 0.99-0.9\\): 0.01376$")
 })

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -7,7 +7,7 @@ test_that("print.auc works", {
 	expect_output(print(auc(r.wfns)), "^Area under the curve: 0.8237$")
 	expect_output(print(auc(r.ndka.percent)), "^Area under the curve: 61.2%$")
 	
-	expect_output(print(r.ndka.partial$auc), "^Partial area under the curve \\(specificity 1-0.9\\): 0.0107$")
+	expect_output(print(r.ndka.partial1$auc), "^Partial area under the curve \\(specificity 1-0.9\\): 0.0107$")
 	expect_output(print(r.s100b.percent.partial1$auc), "^Partial area under the curve \\(specificity 99%-90%\\): 2.983%$")
 	expect_output(print(r.s100b.partial2$auc), "^Partial area under the curve \\(sensitivity 0.99-0.9\\): 0.01376$")
 })

--- a/tests/testthat/test-roc.test.R
+++ b/tests/testthat/test-roc.test.R
@@ -3,11 +3,13 @@ data(aSAH)
 
 context("roc.test")
 
+# define variables shared among multiple tests here
+roc.test_env <- environment()
 
 test_that("roc.test works", {
-	t1 <<- roc.test(r.wfns, r.s100b)
-	t2 <<- roc.test(r.wfns, r.ndka)
-	t3 <<- roc.test(r.ndka, r.s100b)
+	roc.test_env$t1 <- roc.test(r.wfns, r.s100b)
+	roc.test_env$t2 <- roc.test(r.wfns, r.ndka)
+	roc.test_env$t3 <- roc.test(r.ndka, r.s100b)
 	expect_is(t1, "htest")
 	expect_is(t2, "htest")
 	expect_is(t3, "htest")
@@ -67,9 +69,9 @@ test_that("two.sided roc.test produces identical p values when roc curves are re
 
 test_that("unpaired roc.test works", {
 	# Warns about pairing
-	expect_warning(t1up <<- roc.test(r.wfns, r.s100b, paired = FALSE))
-	expect_warning(t2up <<- roc.test(r.wfns, r.ndka, paired = FALSE))
-	expect_warning(t3up <<- roc.test(r.ndka, r.s100b, paired = FALSE))
+	expect_warning(roc.test_env$t1up <- roc.test(r.wfns, r.s100b, paired = FALSE))
+	expect_warning(roc.test_env$t2up <- roc.test(r.wfns, r.ndka, paired = FALSE))
+	expect_warning(roc.test_env$t3up <- roc.test(r.ndka, r.s100b, paired = FALSE))
 })
 
 test_that("unpaired roc.test statistic and p are as expected", {


### PR DESCRIPTION
Ran into an obscure issue in testing where `t2` wound up with a locked binding and `t2 <<-` failed.

This is probably a specific issue to my setup, but gets at why `<<-` is better avoided if possible -- it's hard to debug and cascading assignment can have hard-to-predict side effects. Instead, assigning to a specific environment makes it clearer where the object should be used.

IIUC, this also makes the tests more hermetic as testthat will clean up the variables defined within each test file.