### PR TITLE
typos in comments

### DIFF
--- a/R/roc.utils.R
+++ b/R/roc.utils.R
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Helper functions for the ROC curves. These functions should not be called directly as they peform very specific tasks and do nearly no argument validity checks. Not documented in RD and not exported.
+# Helper functions for the ROC curves. These functions should not be called directly as they perform very specific tasks and do nearly no argument validity checks. Not documented in RD and not exported.
 
 # returns a list of sensitivities (se) and specificities (sp) for the given data. Robust algorithm
 roc_utils_perfs_all_safe <- function(thresholds, controls, cases, direction) {

--- a/tests/testthat/test-roc.R
+++ b/tests/testthat/test-roc.R
@@ -426,7 +426,7 @@ test_that("roc works with `with` and formula", {
 	# Now this can work with #111
 	with(aSAH, roc(form))
 	
-	# Wrapping functinos can mess things up...
+	# Wrapping functions can mess things up...
 	wrap_roc <- function(formula) {
 		roc(formula)
 	}


### PR DESCRIPTION
Sorry for the trivial PR :)

Full context: actually I first opened the branch as our tool flags "splitted":

https://github.com/xrobin/pROC/blob/f03d24652333f18306511a0571bc9aaed320e03a/R/roc.R#L238

I actually don't have any issue with using 'splitted' as a variable name for shorthand. But I only noticed this after already starting the PR so I figured I'd send along as it's better than deleting the corrections I'd already made.