### PR TITLE
Use explicit imports for plyr

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -167,5 +167,6 @@ S3method("ci", "se")
 S3method("ci", "sp")
 S3method("ci", "thresholds")
 
-import(plyr, Rcpp, grDevices, graphics, stats)
+import(Rcpp, grDevices, graphics, stats)
+importFrom(plyr, laply, ldply, llply, progress_none, progress_text, raply)
 useDynLib(pROC, .registration = TRUE)


### PR DESCRIPTION
This makes the dependency structure on {plyr} clearer. In later PRs I'll propose refactoring these away to drop requiring this long-superseded package.